### PR TITLE
Add owner and group to file parameters

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,6 +7,8 @@ class npsradius::config (
   file { $configfile:
     ensure  => present,
     content => template($configtemplate),
+    owner   => admin
+    group   => Administrators
   }
 
   exec { 'npsradius-checkandconfig':


### PR DESCRIPTION
Windows complains that root does not exist (well obviously), resolve this by specifying the owner and groups attribute in file.